### PR TITLE
Add transaction helper and apply to more modules

### DIFF
--- a/BackEnd/controllers/lugaresController.js
+++ b/BackEnd/controllers/lugaresController.js
@@ -44,7 +44,7 @@ module.exports = {
     }
 
     try {
-      await db.tx('crear-lugar', async (t) => {
+      await db.transaccion(async (t) => {
         const direccion_id = uuidv4();
         await t.none(
           `

--- a/BackEnd/controllers/pagoController.js
+++ b/BackEnd/controllers/pagoController.js
@@ -33,13 +33,6 @@ module.exports = {
       const imagen_pago = `/public/uploads/${req.file.filename}`;
       const pagoCompleto = es_pago_completo === "true";
 
-      await pagoModel.registrarPago({
-        reserva_id,
-        monto,
-        imagen_pago,
-        es_pago_completo: pagoCompleto
-      });
-
       const transacciones = [];
 
       if (pagoCompleto) {
@@ -72,7 +65,15 @@ module.exports = {
         }
       }
 
-      await pagoModel.registrarTransacciones(transacciones);
+      await pagoModel.registrarPagoConTransacciones(
+        {
+          reserva_id,
+          monto,
+          imagen_pago,
+          es_pago_completo: pagoCompleto
+        },
+        transacciones
+      );
 
       res.json({ success: true });
     } catch (error) {

--- a/BackEnd/models/dao.js
+++ b/BackEnd/models/dao.js
@@ -16,6 +16,10 @@ class DAO {
   getDb() {
     return db;
   }
+
+  transaccion(fn) {
+    return db.tx(fn);
+  }
 }
 
 module.exports = DAO;

--- a/BackEnd/models/lugarModel.js
+++ b/BackEnd/models/lugarModel.js
@@ -66,7 +66,7 @@ class LugarModel {
 }
 
   async crearLugar(data) {
-    return db.tx(async t => {
+    return db.transaccion(async t => {
       const direccionId = uuidv4();
       await t.none(`
         INSERT INTO direccion(id, ciudad, calle, numero, referencia)

--- a/BackEnd/models/pagoModel.js
+++ b/BackEnd/models/pagoModel.js
@@ -19,6 +19,29 @@ class PagoModel {
       await db.consultar(sql, [item.reserva_id, item.concepto, item.monto]);
     }
   }
+
+  async registrarPagoConTransacciones(pagoData, transacciones) {
+    return db.transaccion(async t => {
+      const sqlPago = `
+        INSERT INTO Pago (id, reserva_id, imagen_pago, monto, fecha_pago, es_pago_completo)
+        VALUES (uuid_generate_v4(), $1, $2, $3, CURRENT_DATE, $4)
+      `;
+      await t.none(sqlPago, [
+        pagoData.reserva_id,
+        pagoData.imagen_pago,
+        pagoData.monto,
+        pagoData.es_pago_completo
+      ]);
+
+      for (const item of transacciones) {
+        const sql = `
+          INSERT INTO DetalleTransaccion (id, reserva_id, concepto, monto)
+          VALUES (uuid_generate_v4(), $1, $2, $3)
+        `;
+        await t.none(sql, [item.reserva_id, item.concepto, item.monto]);
+      }
+    });
+  }
 }
 
 module.exports = PagoModel;

--- a/BackEnd/models/reservaModel.js
+++ b/BackEnd/models/reservaModel.js
@@ -3,22 +3,23 @@ const db = new DAO();
 
 class ReservaModel {
   async crearReserva(data) {
-    const sql = `
-      INSERT INTO Reserva (id, usuario_id, lugar_id, tipo_evento_id, fecha_inicio, fecha_fin, estado, cantidad, total, created_at)
-      VALUES (uuid_generate_v4(), $1, $2, $3, $4, $5, 'pendiente', $6, $7, CURRENT_DATE)
-      RETURNING id;
-    `;
-    const params = [
-      data.usuario_id,
-      data.lugar_id,
-      data.tipo_evento_id,
-      data.fecha_inicio,
-      data.fecha_fin,
-      data.cantidad,
-      data.total
-    ];
-    const result = await db.consultar(sql, params);
-    return result[0];
+    return db.transaccion(async t => {
+      const sql = `
+        INSERT INTO Reserva (id, usuario_id, lugar_id, tipo_evento_id, fecha_inicio, fecha_fin, estado, cantidad, total, created_at)
+        VALUES (uuid_generate_v4(), $1, $2, $3, $4, $5, 'pendiente', $6, $7, CURRENT_DATE)
+        RETURNING id;
+      `;
+      const params = [
+        data.usuario_id,
+        data.lugar_id,
+        data.tipo_evento_id,
+        data.fecha_inicio,
+        data.fecha_fin,
+        data.cantidad,
+        data.total
+      ];
+      return await t.one(sql, params);
+    });
   }
 
   async obtenerReservasPorLugar(lugarId) {


### PR DESCRIPTION
## Summary
- add `transaccion` helper in DAO for easy pg-promise transactions
- refactor controllers and models to use this helper when creating records

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684eef15899483219fd81d01873d1531