### PR TITLE
Enable 20 image uploads for places

### DIFF
--- a/BackEnd/routes/lugarRoute.js
+++ b/BackEnd/routes/lugarRoute.js
@@ -8,6 +8,7 @@ router.get('/:id', lugarController.obtenerLugarPorId);
 router.get('/:id/resenas', lugarController.obtenerResenasLugar);
 
 // Nuevo endpoint para crear lugar con subida de múltiples imágenes
-router.post('/', upload.array('photos', 10), lugarController.crearLugar);
+// Permitir hasta 20 imágenes por lugar
+router.post('/', upload.array('photos', 20), lugarController.crearLugar);
 
 module.exports = router;

--- a/FrontEnd/publicar.html
+++ b/FrontEnd/publicar.html
@@ -37,6 +37,7 @@
       <div>
         <label class="block font-semibold text-sm text-gray-700 mb-1">Fotos del lugar</label>
         <input type="file" name="photos" accept="image/*" multiple required class="w-full border px-4 py-2 rounded" />
+        <p class="text-xs text-gray-500 mt-1">Puedes seleccionar hasta 20 imágenes.</p>
       </div>
 
       <div class="mb-4">


### PR DESCRIPTION
## Summary
- allow up to 20 images when creating a place
- show info about the image limit on the publish form

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685034027f5c8321a304550e2d76da0d